### PR TITLE
Fix taxonomy fields slug values

### DIFF
--- a/includes/types/CMB2_Type_Taxonomy_Base.php
+++ b/includes/types/CMB2_Type_Taxonomy_Base.php
@@ -38,15 +38,11 @@ abstract class CMB2_Type_Taxonomy_Base extends CMB2_Type_Multi_Base {
 		}
 
 
-		// Backward compatible.
-		if ( ! is_numeric( $value) && $term->slug === $value ) {
-			return true;
+		// Backward compatible for slug values.
+		if ( ! is_numeric( $value ) ) {
+			return $term->slug === $value;
 		}
-
-		if ( (int) $value === $term->term_id ) {
-			return true;
-		}
-		return false;
+		return (int) $value === $term->term_id;
 	}
 
 	/**


### PR DESCRIPTION
If a taxonomy value is the slug, we must return the 
result immediately instead of continuing to check
against term_id for match. Otherwise, the slug will
translate to `1` when cast to (int) and match the
uncategorized term_id.


